### PR TITLE
"provided" scope dependencies are missed during generation

### DIFF
--- a/src/main/java/org/assertj/maven/AssertJAssertionsGeneratorMojo.java
+++ b/src/main/java/org/assertj/maven/AssertJAssertionsGeneratorMojo.java
@@ -107,10 +107,10 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
 
   private ClassLoader getProjectClassLoader() throws DependencyResolutionRequiredException, MalformedURLException {
     @SuppressWarnings("unchecked")
-    List<String> runtimeClasspathElements = project.getRuntimeClasspathElements();
-    URL[] runtimeUrls = new URL[runtimeClasspathElements.size()];
-    for (int i = 0; i < runtimeClasspathElements.size(); i++) {
-      runtimeUrls[i] = new File(runtimeClasspathElements.get(i)).toURI().toURL();
+    List<String> compileClasspathElements = project.getCompileClasspathElements();
+    URL[] runtimeUrls = new URL[compileClasspathElements.size()];
+    for (int i = 0; i < compileClasspathElements.size(); i++) {
+      runtimeUrls[i] = new File(compileClasspathElements.get(i)).toURI().toURL();
     }
     return new URLClassLoader(runtimeUrls, Thread.currentThread().getContextClassLoader());
   }

--- a/src/test/java/org/assertj/maven/AssertJAssertionsGeneratorMojoTest.java
+++ b/src/test/java/org/assertj/maven/AssertJAssertionsGeneratorMojoTest.java
@@ -48,7 +48,7 @@ public class AssertJAssertionsGeneratorMojoTest {
     assertjAssertionsGeneratorMojo.packages = array("org.assertj.maven.test", "org.assertj.maven.test2");
     assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
     List<String> classes = newArrayList(Employee.class.getName(), Address.class.getName());
-    when(mavenProject.getRuntimeClasspathElements()).thenReturn(classes);
+    when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
 
     assertjAssertionsGeneratorMojo.execute();
 
@@ -66,7 +66,7 @@ public class AssertJAssertionsGeneratorMojoTest {
     assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
     assertjAssertionsGeneratorMojo.hierarchical = true;
     List<String> classes = newArrayList(Employee.class.getName(), Address.class.getName());
-    when(mavenProject.getRuntimeClasspathElements()).thenReturn(classes);
+    when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
 
     assertjAssertionsGeneratorMojo.execute();
 
@@ -94,7 +94,7 @@ public class AssertJAssertionsGeneratorMojoTest {
     assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee", "org.assertj.maven.test2.adress.Address");
     List<String> classes = newArrayList(Address.class.getName());
     assertjAssertionsGeneratorMojo.hierarchical = true;
-    when(mavenProject.getRuntimeClasspathElements()).thenReturn(classes);
+    when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
 
     assertjAssertionsGeneratorMojo.execute();
 
@@ -111,7 +111,7 @@ public class AssertJAssertionsGeneratorMojoTest {
     assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
     assertjAssertionsGeneratorMojo.entryPointClassPackage = "my.custom.pkg";
     List<String> classes = newArrayList(Employee.class.getName(), Address.class.getName());
-    when(mavenProject.getRuntimeClasspathElements()).thenReturn(classes);
+    when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
 
     assertjAssertionsGeneratorMojo.execute();
 
@@ -123,7 +123,7 @@ public class AssertJAssertionsGeneratorMojoTest {
   public void executing_plugin_with_fake_package_should_not_generate_anything() throws Exception {
     assertjAssertionsGeneratorMojo.packages = array("fakepackage");
     List<String> classes = newArrayList();
-    when(mavenProject.getRuntimeClasspathElements()).thenReturn(classes);
+    when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
 
     assertjAssertionsGeneratorMojo.execute();
 
@@ -134,7 +134,7 @@ public class AssertJAssertionsGeneratorMojoTest {
   @Test
   public void executing_plugin_with_error_should_be_reported_in_generator_report() throws Exception {
     assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
-    when(mavenProject.getRuntimeClasspathElements()).thenReturn(newArrayList(Employee.class.getName()));
+    when(mavenProject.getCompileClasspathElements()).thenReturn(newArrayList(Employee.class.getName()));
     // let's throws an IOException when generating custom assertions
     AssertionsGenerator generator = new AssertionsGenerator(Thread.currentThread().getContextClassLoader());
     BaseAssertionGenerator baseGenerator = mock(BaseAssertionGenerator.class);


### PR DESCRIPTION
While the mojo specifies `requiresDependencyResolution = COMPILE_PLUS_RUNTIME` only uses runtime dependencies (via `project.getRuntimeClasspathElements()`). getRuntimeClasspathElements filters dependencies by:

``` java
if ( Artifact.SCOPE_COMPILE.equals( a.getScope() ) || Artifact.SCOPE_RUNTIME.equals( a.getScope() ) )
```

It should instead be calling `project.getCompileClasspathElements` which filters by:

``` java
if ( Artifact.SCOPE_COMPILE.equals( a.getScope() ) || Artifact.SCOPE_PROVIDED.equals( a.getScope() ) ||
                    Artifact.SCOPE_SYSTEM.equals( a.getScope() ) )
```

Which includes `<scope>provided</scope>` dependencies.

I've tested this on a simple web project where `javax.servlet:javax.servlet-api` breaks the current 1.2.0 version) and confirmed that this works with this patch.

Not sure if there's a meaningful unit test that can be added to support this (given it requires a whole separate project, etc).

M
