### PR TITLE
Update assertj-assertions-generator to project.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-assertions-generator</artifactId>
-      <version>2.0.0</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>


### PR DESCRIPTION
This will use the same version as the plugin's version.
