### PR TITLE
Ability to define compile/test (default) scope for generated sources

### DIFF
--- a/src/main/java/org/assertj/maven/AssertJAssertionsGeneratorMojo.java
+++ b/src/main/java/org/assertj/maven/AssertJAssertionsGeneratorMojo.java
@@ -69,12 +69,12 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
    * Expected to be used in conjunction with {@link #targetDir}, for example:
    * <pre>{@code
    *  <targetDir>${project.build.directory}/generated-sources/assertj-assertions</targetDir>
-   *  <targetScope>compile</targetScope>
+   *  <generatedSourcesScope>compile</generatedSourcesScope>
    * }</pre>
    * Defaults to 'test'.<br>
    */
-  @Parameter(defaultValue = "test", property = "assertj.targetType")
-  public String targetScope;
+  @Parameter(defaultValue = "test", property = "assertj.generatedSourcesScope")
+  public String generatedSourcesScope;
 
   /**
    * List of packages to generate assertions for.
@@ -184,9 +184,9 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
                                                                                          entryPointClassPackage,
                                                                                          hierarchical, templates);
 	getLog().info(generatorReport.getReportContent());
-	if (isEmpty(targetScope) || equalsIgnoreCase("test", targetScope)) project.addTestCompileSourceRoot(targetDir);
-	else if (equalsIgnoreCase("compile", targetScope)) project.addCompileSourceRoot(targetDir);
-	else getLog().warn(format("Unknown target scope '%s' - no sources added to project", targetScope));
+	if (isEmpty(generatedSourcesScope) || equalsIgnoreCase("test", generatedSourcesScope)) project.addTestCompileSourceRoot(targetDir);
+	else if (equalsIgnoreCase("compile", generatedSourcesScope)) project.addCompileSourceRoot(targetDir);
+	else getLog().warn(format("Unknown generated sources scope '%s' - no sources added to project", generatedSourcesScope));
 	return generatorReport;
   }
 

--- a/src/main/java/org/assertj/maven/AssertJAssertionsGeneratorMojo.java
+++ b/src/main/java/org/assertj/maven/AssertJAssertionsGeneratorMojo.java
@@ -14,6 +14,8 @@ package org.assertj.maven;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.ArrayUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.maven.plugins.annotations.LifecyclePhase.GENERATE_TEST_SOURCES;
 import static org.apache.maven.plugins.annotations.ResolutionScope.TEST;
 import static org.assertj.assertions.generator.AssertionsEntryPointType.BDD;
@@ -61,6 +63,18 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
    */
   @Parameter(defaultValue = "${project.build.directory}/generated-test-sources/assertj-assertions", property = "assertj.targetDir")
   public String targetDir;
+
+  /**
+   * The scope of generates sources ('test' or 'compile') to be added to the maven build. <br>
+   * Expected to be used in conjunction with {@link #targetDir}, for example:
+   * <pre>{@code
+   *  <targetDir>${project.build.directory}/generated-sources/assertj-assertions</targetDir>
+   *  <targetScope>compile</targetScope>
+   * }</pre>
+   * Defaults to 'test'.<br>
+   */
+  @Parameter(defaultValue = "test", property = "assertj.targetType")
+  public String targetScope;
 
   /**
    * List of packages to generate assertions for.
@@ -170,7 +184,9 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
                                                                                          entryPointClassPackage,
                                                                                          hierarchical, templates);
 	getLog().info(generatorReport.getReportContent());
-	project.addTestCompileSourceRoot(targetDir);
+	if (isEmpty(targetScope) || equalsIgnoreCase("test", targetScope)) project.addTestCompileSourceRoot(targetDir);
+	else if (equalsIgnoreCase("compile", targetScope)) project.addCompileSourceRoot(targetDir);
+	else getLog().warn(format("Unknown target scope '%s' - no sources added to project", targetScope));
 	return generatorReport;
   }
 

--- a/src/test/java/org/assertj/maven/AssertJAssertionsGeneratorMojoTest.java
+++ b/src/test/java/org/assertj/maven/AssertJAssertionsGeneratorMojoTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.maven.AssertJAssertionsGeneratorMojo.shouldHaveNonEmptyPackagesOrClasses;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -339,6 +341,67 @@ public class AssertJAssertionsGeneratorMojoTest {
     } catch (MojoFailureException e) {
       assertThat(e).hasMessage(shouldHaveNonEmptyPackagesOrClasses());
     }
+  }
+
+  @Test
+  public void executing_plugin_with_default_target_scope_should_pass() throws Exception {
+    assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
+    assertjAssertionsGeneratorMojo.entryPointClassPackage = "my.custom.pkg";
+    List<String> classes = newArrayList(Employee.class.getName(), Address.class.getName());
+    when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
+
+    assertjAssertionsGeneratorMojo.execute();
+
+    assertThat(assertionsFileFor(Employee.class)).exists();
+    assertThat(assertionsEntryPointFileWithCustomPackage()).exists();
+    verify(mavenProject).addTestCompileSourceRoot(assertjAssertionsGeneratorMojo.targetDir);
+  }
+
+  @Test
+  public void executing_plugin_with_test_target_scope_should_pass() throws Exception {
+    assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
+    assertjAssertionsGeneratorMojo.entryPointClassPackage = "my.custom.pkg";
+    assertjAssertionsGeneratorMojo.targetScope = "test";
+    List<String> classes = newArrayList(Employee.class.getName(), Address.class.getName());
+    when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
+
+    assertjAssertionsGeneratorMojo.execute();
+
+    assertThat(assertionsFileFor(Employee.class)).exists();
+    assertThat(assertionsEntryPointFileWithCustomPackage()).exists();
+    verify(mavenProject).addTestCompileSourceRoot(assertjAssertionsGeneratorMojo.targetDir);
+  }
+
+  @Test
+  public void executing_plugin_with_compile_target_scope_should_pass() throws Exception {
+    assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
+    assertjAssertionsGeneratorMojo.entryPointClassPackage = "my.custom.pkg";
+    assertjAssertionsGeneratorMojo.targetScope = "compile";
+    List<String> classes = newArrayList(Employee.class.getName(), Address.class.getName());
+    when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
+
+    assertjAssertionsGeneratorMojo.execute();
+
+    assertThat(assertionsFileFor(Employee.class)).exists();
+    assertThat(assertionsEntryPointFileWithCustomPackage()).exists();
+    verify(mavenProject).addCompileSourceRoot(assertjAssertionsGeneratorMojo.targetDir);
+  }
+
+
+  @Test
+  public void executing_plugin_with_invalid_target_scope_should_pass() throws Exception {
+    assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
+    assertjAssertionsGeneratorMojo.entryPointClassPackage = "my.custom.pkg";
+    assertjAssertionsGeneratorMojo.targetScope = "invalid";
+    List<String> classes = newArrayList(Employee.class.getName(), Address.class.getName());
+    when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
+
+    assertjAssertionsGeneratorMojo.execute();
+
+    assertThat(assertionsFileFor(Employee.class)).exists();
+    assertThat(assertionsEntryPointFileWithCustomPackage()).exists();
+    verify(mavenProject, never()).addCompileSourceRoot(assertjAssertionsGeneratorMojo.targetDir);
+    verify(mavenProject, never()).addTestCompileSourceRoot(assertjAssertionsGeneratorMojo.targetDir);
   }
 
   private File assertionsFileFor(Class<?> clazz) {

--- a/src/test/java/org/assertj/maven/AssertJAssertionsGeneratorMojoTest.java
+++ b/src/test/java/org/assertj/maven/AssertJAssertionsGeneratorMojoTest.java
@@ -361,7 +361,7 @@ public class AssertJAssertionsGeneratorMojoTest {
   public void executing_plugin_with_test_target_scope_should_pass() throws Exception {
     assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
     assertjAssertionsGeneratorMojo.entryPointClassPackage = "my.custom.pkg";
-    assertjAssertionsGeneratorMojo.targetScope = "test";
+    assertjAssertionsGeneratorMojo.generatedSourcesScope = "test";
     List<String> classes = newArrayList(Employee.class.getName(), Address.class.getName());
     when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
 
@@ -376,7 +376,7 @@ public class AssertJAssertionsGeneratorMojoTest {
   public void executing_plugin_with_compile_target_scope_should_pass() throws Exception {
     assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
     assertjAssertionsGeneratorMojo.entryPointClassPackage = "my.custom.pkg";
-    assertjAssertionsGeneratorMojo.targetScope = "compile";
+    assertjAssertionsGeneratorMojo.generatedSourcesScope = "compile";
     List<String> classes = newArrayList(Employee.class.getName(), Address.class.getName());
     when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
 
@@ -392,7 +392,7 @@ public class AssertJAssertionsGeneratorMojoTest {
   public void executing_plugin_with_invalid_target_scope_should_pass() throws Exception {
     assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.test.Employee");
     assertjAssertionsGeneratorMojo.entryPointClassPackage = "my.custom.pkg";
-    assertjAssertionsGeneratorMojo.targetScope = "invalid";
+    assertjAssertionsGeneratorMojo.generatedSourcesScope = "invalid";
     List<String> classes = newArrayList(Employee.class.getName(), Address.class.getName());
     when(mavenProject.getCompileClasspathElements()).thenReturn(classes);
 


### PR DESCRIPTION
We occasionally build common test modules which can then be included in other modules. With the plugin as it currently stands, generated sources are always added as test sources via `project.addTestCompileSourceRoot(targetDir)`. As such, we need to build a "-tests" jar which includes the generated assertions, however that then brings along any other actual tests for the tests module (sorry, getting a bit meta).

It would be great to have additional (optional) configuration which allows the specification of the target scope to which would determine whether `project.addTestCompileSourceRoot(targetDir)` or `project.addCompileSourceRoot(targetDir)` is used. Something like:

```xml
<targetDir>${project.build.directory}/generated-sources/assertj-assertions</targetDir>
<targetScope>compile</targetScope>
```

I have a PR in hand for this, but happy to hear feedback on naming before putting that through