### PR TITLE
Fixes #46 (depends on assertj-assertions-generator #129)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-assertions-generator</artifactId>
-      <version>2.1.0</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/src/main/java/org/assertj/maven/AssertJAssertionsGeneratorMojo.java
+++ b/src/main/java/org/assertj/maven/AssertJAssertionsGeneratorMojo.java
@@ -70,10 +70,10 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
   public String targetDir;
 
   /**
-   * Package where generated assertion classes will reside. 
+   * Package where generated assertion classes will reside.
    * <p/>
    * If not set (or set to empty), each assertion class is generated in the package of the corresponding class to assert.
-   * For example the generated assertion class for com.nba.Player will be com.nba.PlayerAssert (in the same package as Player). 
+   * For example the generated assertion class for com.nba.Player will be com.nba.PlayerAssert (in the same package as Player).
    * Defaults to ''.<br>
    * <p/>
    * Note that the Assertions entry point classes package is controlled by the entryPointClassPackage property.
@@ -192,6 +192,12 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
   @Parameter(property = "assertj.templates")
   public Templates templates;
 
+  /**
+   * Generate assertions for package private classes if true
+   */
+  @Parameter(property = "assertj.includePackagePrivateClasses")
+  public boolean includePackagePrivateClasses = false;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (skip) {
@@ -215,7 +221,7 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
       }
       assertionGenerator.setLog(getLog());
       if (generateAssertionsInPackage != null) {
-        // user has set generateAssertionsInPackage  (not that maven converts empty string param to null) 
+        // user has set generateAssertionsInPackage  (not that maven converts empty string param to null)
         assertionGenerator.setGeneratedAssertionsPackage(generateAssertionsInPackage);
       }
       if (cleanTargetDir) cleanPreviouslyGeneratedSources();
@@ -246,8 +252,8 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
   AssertionsGeneratorReport executeWithAssertionGenerator(AssertionsGenerator assertionGenerator) {
     if (classes == null) classes = new String[0];
     AssertionsGeneratorReport generatorReport = assertionGenerator.generateAssertionsFor(packages, classes, targetDir,
-                                                                                         entryPointClassPackage,
-                                                                                         hierarchical, templates);
+                                                                                         entryPointClassPackage, hierarchical,
+                                                                                         templates, includePackagePrivateClasses);
     printReport(generatorReport);
     if (isEmpty(generatedSourcesScope) || equalsIgnoreCase("test", generatedSourcesScope)) project.addTestCompileSourceRoot(targetDir);
     else if (equalsIgnoreCase("compile", generatedSourcesScope)) project.addCompileSourceRoot(targetDir);

--- a/src/main/java/org/assertj/maven/generator/AssertionsGenerator.java
+++ b/src/main/java/org/assertj/maven/generator/AssertionsGenerator.java
@@ -83,17 +83,18 @@ public class AssertionsGenerator {
   /**
    * Generates custom assertions for classes in given packages with the Assertions class entry point in given
    * destination dir.
-   * 
+   *
    * @param inputPackages the packages containing the classes we want to generate Assert classes for.
    * @param inputClassNames the packages containing the classes we want to generate Assert classes for.
    * @param destDir the base directory where the classes are going to be generated.
    * @param entryPointFilePackage the package of the assertions entry point class, may be <code>null</code>.
+   * @param includePackagePrivateClasses collect package private classes if true.
    * @throws IOException if the files can't be generated
    */
   @SuppressWarnings("unchecked")
   public AssertionsGeneratorReport generateAssertionsFor(String[] inputPackages, String[] inputClassNames,
-                                                         String destDir, String entryPointFilePackage,
-                                                         boolean hierarchical, Templates userTemplates) {
+                                                         String destDir, String entryPointFilePackage, boolean hierarchical,
+                                                         Templates userTemplates, boolean includePackagePrivateClasses) {
     generator.setDirectoryWhereAssertionFilesAreGenerated(new File(destDir));
     AssertionsGeneratorReport report = new AssertionsGeneratorReport();
     report.setDirectoryPathWhereAssertionFilesAreGenerated(destDir);
@@ -102,7 +103,7 @@ public class AssertionsGenerator {
     report.setInputPackages(inputPackages);
     report.setInputClasses(inputClassNames);
     try {
-      Set<TypeToken<?>> classes = collectClasses(classLoader, addAll(inputPackages, inputClassNames));
+      Set<TypeToken<?>> classes = collectClasses(classLoader, includePackagePrivateClasses, addAll(inputPackages, inputClassNames));
       report.reportInputClassesNotFound(classes, inputClassNames);
       Set<TypeToken<?>> filteredClasses = removeAssertClasses(classes);
       removeClassesAccordingToIncludeAndExcludePatterns(filteredClasses);

--- a/src/test/java/org/assertj/maven/AssertJAssertionsGeneratorMojoTest.java
+++ b/src/test/java/org/assertj/maven/AssertJAssertionsGeneratorMojoTest.java
@@ -491,6 +491,31 @@ public class AssertJAssertionsGeneratorMojoTest {
     verify(mavenProject, never()).addTestCompileSourceRoot(assertjAssertionsGeneratorMojo.targetDir);
   }
 
+  @Test
+  public void plugin_should_generate_assertions_for_included_package_private_classes_when_option_enabled() throws Exception {
+    // GIVEN
+    assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.PackagePrivate");
+    assertjAssertionsGeneratorMojo.includePackagePrivateClasses = true;
+    when(mavenProject.getCompileClasspathElements()).thenReturn(newArrayList(PackagePrivate.class.getName()));
+    AssertionsGenerator generator = new AssertionsGenerator(Thread.currentThread().getContextClassLoader());
+    // WHEN
+    assertjAssertionsGeneratorMojo.executeWithAssertionGenerator(generator);
+    // THEN
+    assertThat(assertionsFileFor(PackagePrivate.class)).exists();
+  }
+
+  @Test
+  public void plugin_should_not_generate_assertions_for_included_package_private_classes_by_default() throws Exception {
+    // GIVEN
+    assertjAssertionsGeneratorMojo.classes = array("org.assertj.maven.PackagePrivate");
+    when(mavenProject.getCompileClasspathElements()).thenReturn(newArrayList(PackagePrivate.class.getName()));
+    AssertionsGenerator generator = new AssertionsGenerator(Thread.currentThread().getContextClassLoader());
+    // WHEN
+    assertjAssertionsGeneratorMojo.executeWithAssertionGenerator(generator);
+    // THEN
+    assertThat(assertionsFileFor(PackagePrivate.class)).doesNotExist();
+  }
+
   private File assertionsFileFor(Class<?> clazz) {
     return new File(temporaryFolder.getRoot(), basePathName(clazz) + "Assert.java");
   }

--- a/src/test/java/org/assertj/maven/PackagePrivate.java
+++ b/src/test/java/org/assertj/maven/PackagePrivate.java
@@ -1,0 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+package org.assertj.maven;
+
+class PackagePrivate {
+}


### PR DESCRIPTION
Add a new option named includePackagePrivateClasses to collect package private classes when true, false by default.