### PR TITLE
#93: added an option to choose between the javax and jakarta generated annotation.

### DIFF
--- a/src/main/java/org/assertj/maven/AssertJAssertionsGeneratorMojo.java
+++ b/src/main/java/org/assertj/maven/AssertJAssertionsGeneratorMojo.java
@@ -41,6 +41,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.assertj.assertions.generator.GeneratedAnnotationSource;
 import org.assertj.core.util.VisibleForTesting;
 import org.assertj.maven.generator.AssertionsGenerator;
 import org.assertj.maven.generator.AssertionsGeneratorReport;
@@ -198,6 +199,12 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
   @Parameter(property = "assertj.includePackagePrivateClasses")
   public boolean includePackagePrivateClasses = false;
 
+  /**
+   * Where the @Generated annotation should come from. Options: JAVAX (default), JAKARTA, NONE.
+   */
+  @Parameter(property = "assertj.annotationSource")
+  public GeneratedAnnotationSource generatedAnnotationSource = GeneratedAnnotationSource.JAVAX;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (skip) {
@@ -211,6 +218,7 @@ public class AssertJAssertionsGeneratorMojo extends AbstractMojo {
       assertionGenerator.generateAssertionsForAllFields(this.generateAssertionsForAllFields);
       assertionGenerator.setIncludePatterns(includes);
       assertionGenerator.setExcludePatterns(excludes);
+      assertionGenerator.setGeneratedAnnotationSource(generatedAnnotationSource);
       if (generateAssertions) assertionGenerator.enableEntryPointClassesGenerationFor(STANDARD);
       if (generateBddAssertions) assertionGenerator.enableEntryPointClassesGenerationFor(BDD);
       if (generateSoftAssertions) assertionGenerator.enableEntryPointClassesGenerationFor(SOFT);

--- a/src/main/java/org/assertj/maven/generator/AssertionsGenerator.java
+++ b/src/main/java/org/assertj/maven/generator/AssertionsGenerator.java
@@ -30,6 +30,7 @@ import com.google.common.reflect.TypeToken;
 import org.apache.maven.plugin.logging.Log;
 import org.assertj.assertions.generator.AssertionsEntryPointType;
 import org.assertj.assertions.generator.BaseAssertionGenerator;
+import org.assertj.assertions.generator.GeneratedAnnotationSource;
 import org.assertj.assertions.generator.Template;
 import org.assertj.assertions.generator.description.ClassDescription;
 import org.assertj.assertions.generator.description.converter.ClassToClassDescriptionConverter;
@@ -202,5 +203,9 @@ public class AssertionsGenerator {
 
   public void setGeneratedAssertionsPackage(String generateAssertionsInPackage) {
     this.generator.setGeneratedAssertionsPackage(generateAssertionsInPackage);
+  }
+
+  public void setGeneratedAnnotationSource(GeneratedAnnotationSource generatedAnnotationSource) {
+    generator.setGeneratedAnnotationSource(generatedAnnotationSource);
   }
 }


### PR DESCRIPTION
fixes #93
requires https://github.com/assertj/assertj-assertions-generator/issues/194 to be merged first, since methods/classes introduced with that issue are used here.