### PR TITLE
feature(#110): use Objects::deepEquals instead of deprecated Objects:…

### DIFF
--- a/src/test/resources/templates/my_has_assertion_template.txt
+++ b/src/test/resources/templates/my_has_assertion_template.txt
@@ -14,7 +14,7 @@
     
     // null safe check
     ${propertyType} actual${Property} = actual.get${Property}();
-    if (!Objects.areEqual(actual${Property}, ${property_safe})) {
+    if (!Objects.deepEquals(actual${Property}, ${property_safe})) {
       failWithMessage(assertjErrorMessage, actual, ${property_safe}, actual${Property});
     }
 

--- a/src/test/resources/templates/my_has_assertion_template_for_character.txt
+++ b/src/test/resources/templates/my_has_assertion_template_for_character.txt
@@ -14,7 +14,7 @@
     
     // null safe check
     ${propertyType} actual${Property} = actual.get${Property}();
-    if (!Objects.areEqual(actual${Property}, ${property_safe})) {
+    if (!Objects.deepEquals(actual${Property}, ${property_safe})) {
       failWithMessage(assertjErrorMessage, actual, ${property_safe}, actual${Property});
     }
 

--- a/src/test/resources/templates/my_has_assertion_template_for_primitive_wrapper.txt
+++ b/src/test/resources/templates/my_has_assertion_template_for_primitive_wrapper.txt
@@ -14,7 +14,7 @@
     
     // null safe check
     ${propertyType} actual${Property} = actual.get${Property}();
-    if (!Objects.areEqual(actual${Property}, ${property_safe})) {
+    if (!Objects.deepEquals(actual${Property}, ${property_safe})) {
       failWithMessage(assertjErrorMessage, actual, ${property_safe}, actual${Property});
     }
 

--- a/src/test/resources/templates/my_has_assertion_template_for_real_number_wrapper.txt
+++ b/src/test/resources/templates/my_has_assertion_template_for_real_number_wrapper.txt
@@ -14,7 +14,7 @@
 
     // null safe check
     ${propertyType} actual${Property} = actual.get${Property}();
-    if (!Objects.areEqual(actual${Property}, ${property_safe})) {
+    if (!Objects.deepEquals(actual${Property}, ${property_safe})) {
       failWithMessage(assertjErrorMessage, actual, ${property_safe}, actual${Property});
     }
 

--- a/src/test/resources/templates/my_has_assertion_template_for_whole_number_wrapper.txt
+++ b/src/test/resources/templates/my_has_assertion_template_for_whole_number_wrapper.txt
@@ -14,7 +14,7 @@
     
     // null safe check
     ${propertyType} actual${Property} = actual.get${Property}();
-    if (!Objects.areEqual(actual${Property}, ${property_safe})) {
+    if (!Objects.deepEquals(actual${Property}, ${property_safe})) {
       failWithMessage(assertjErrorMessage, actual, ${property_safe}, actual${Property});
     }
 

--- a/src/test/resources/templates/my_is_wrapper_assertion_template.txt
+++ b/src/test/resources/templates/my_is_wrapper_assertion_template.txt
@@ -9,7 +9,7 @@
     isNotNull();
 
     // null safe check
-    if (Objects.areEqual(Boolean.FALSE, actual.${predicate}())) {
+    if (Objects.deepEquals(Boolean.FALSE, actual.${predicate}())) {
       failWithMessage("\nExpecting that actual ${class_to_assert} ${predicate_for_error_message_part1} but ${predicate_for_error_message_part2}.");
     }
     
@@ -27,7 +27,7 @@
     isNotNull();
 
     // null safe check
-    if (Objects.areEqual(Boolean.TRUE, actual.${predicate}())) {
+    if (Objects.deepEquals(Boolean.TRUE, actual.${predicate}())) {
       failWithMessage("\nExpecting that actual ${class_to_assert} ${negative_predicate_for_error_message_part1} but ${negative_predicate_for_error_message_part2}.");
     }
     


### PR DESCRIPTION
use Objects::deepEquals instead of deprecated Objects::areEqual